### PR TITLE
pureftp: Fix creating multiple users

### DIFF
--- a/blues/pureftp.py
+++ b/blues/pureftp.py
@@ -99,8 +99,10 @@ def configure():
                 user_home = os.path.join(ftp_root, username)
 
             passwd_path = '/etc/pure-ftpd/pureftpd.passwd'
-            if files.exists(passwd_path) and run('pure-pw show {}'.format(username)).return_code == 0:
-                continue
+            with settings(warn_only=True):
+                if files.exists(passwd_path) and run('pure-pw show {}'.format(
+                                                     username)).return_code == 0:
+                    continue
             debian.mkdir(user_home, owner=ftp_user, group=ftp_group)
             prompts = {
                 'Password: ': password,


### PR DESCRIPTION
Make fabric only warn if `pure-pw show` fails, instead of exiting.