### PR TITLE
uwsgi: Chown logfiles to uid:gid by default

### DIFF
--- a/blues/templates/app/uwsgi/default/web.ini
+++ b/blues/templates/app/uwsgi/default/web.ini
@@ -30,6 +30,8 @@ cpu_affinity = {{ cpu_affinity }}
 
 memory-report = true
 
+logfile-chown = true
+
 # NewRelic
 {% if not gevent %}
 enable-threads = true


### PR DESCRIPTION
The uWSGI log files are owned by root by default, unless told to chown them, thus preventing log rotation