### PR TITLE
uwsgi: Chown logfile for everything

### DIFF
--- a/blues/templates/app/uwsgi/default/web.ini
+++ b/blues/templates/app/uwsgi/default/web.ini
@@ -30,8 +30,6 @@ cpu_affinity = {{ cpu_affinity }}
 
 memory-report = true
 
-logfile-chown = true
-
 # NewRelic
 {% if not gevent %}
 enable-threads = true

--- a/blues/templates/uwsgi/uwsgi/default/vassal.ini
+++ b/blues/templates/uwsgi/uwsgi/default/vassal.ini
@@ -10,6 +10,7 @@ home = {{ virtualenv }}
 # Logging
 log-date = true
 logto = /var/log/uwsgi/%n.log
+logfile-chown = true
 
 # Keep processes alive
 master = true


### PR DESCRIPTION
Previous PR just added `logfile-chown` to the file in one of the uwsgi configs in application, instead of making it apply everywhere, even though all projects could use it.