### PR TITLE
app: deploy: Add parameter to return deployed commits

### DIFF
--- a/blues/application/tasks.py
+++ b/blues/application/tasks.py
@@ -76,7 +76,7 @@ def deploy(auto_reload=True, force=False):
         if auto_reload:
             reload()
 
-    return code_changed
+    return (previous_commit, current_commit) if code_changed else False
 
 
 @task


### PR DESCRIPTION
When sending deploy notifications it would be useful to have both the
old and the new commit listed. This change will make that possible.