### PR TITLE
Add blueprint to generate .env file

### DIFF
--- a/blues/pam_env.py
+++ b/blues/pam_env.py
@@ -1,0 +1,50 @@
+"""
+PAM Environment Blueprint
+==============
+
+Updates section of ~/.pam_environment file for specified users defining
+shell envs from the deploy config incl optional extra variables provided
+in settings (which can override shell_env).
+
+**Fabric environment:**
+
+.. code-block:: yaml
+
+    blueprints:
+      - pam_env
+
+    settings:
+      pam_env:
+        all:
+          ALL_USERS_EXTRA_ENV_VAR: "some value"
+        myuser:
+          MYUSER_EXTRA_ENV_VAR: "some value"
+
+"""
+from fabric.decorators import task
+from refabric.contrib import blueprints
+
+__all__ = ['configure']
+
+
+blueprint = blueprints.get(__name__)
+
+
+@task
+def configure():
+    """
+    Update .env file with environment variables
+    """
+    from blues.application.tasks import configure_providers
+    from blues.application.project import project_home, project_name
+    from fabric.state import env
+
+    e = env['shell_env'].copy()
+    e.update(blueprint.settings())
+    escape = lambda v: str(v).replace('\\', '\\\\').replace('"', '\\"')
+    e = map(lambda v: (v[0], escape(v[1])), sorted(e.items()))
+
+    changed = blueprint.upload('./', project_home(), user=project_name(),
+                               context={'shell_env': e})
+    if changed:
+        configure_providers(force_reload=True)

--- a/blues/pam_env.py
+++ b/blues/pam_env.py
@@ -21,8 +21,10 @@ in settings (which can override shell_env).
           MYUSER_EXTRA_ENV_VAR: "some value"
 
 """
+from fabric.contrib import files
 from fabric.decorators import task
 from refabric.contrib import blueprints
+from refabric.operations import run
 from refabric.utils import info
 
 __all__ = ['configure']
@@ -46,6 +48,15 @@ def configure():
 
     changed = blueprint.upload('./', project_home(), user=project_name(),
                                context={'shell_env': e})
+
+    profile = project_home() + '/.profile'
+    cmd = 'source ~/.env'
+    from refabric.context_managers import silent
+    with silent('warnings'):
+        if not run('grep "%s" %s' % (cmd, profile),
+                   user=project_name()).succeeded:
+            files.append(profile, cmd)
+
     if changed:
         info('Environment has been changed')
         configure_providers(force_reload=True)

--- a/blues/pam_env.py
+++ b/blues/pam_env.py
@@ -23,9 +23,9 @@ in settings (which can override shell_env).
 """
 from fabric.decorators import task
 from refabric.contrib import blueprints
+from refabric.utils import info
 
 __all__ = ['configure']
-
 
 blueprint = blueprints.get(__name__)
 
@@ -40,11 +40,12 @@ def configure():
     from fabric.state import env
 
     e = env['shell_env'].copy()
-    e.update(blueprint.settings())
+    e.update(blueprint.settings() or {})
     escape = lambda v: str(v).replace('\\', '\\\\').replace('"', '\\"')
     e = map(lambda v: (v[0], escape(v[1])), sorted(e.items()))
 
     changed = blueprint.upload('./', project_home(), user=project_name(),
                                context={'shell_env': e})
     if changed:
+        info('Environment has been changed')
         configure_providers(force_reload=True)

--- a/blues/templates/pam_env/.pam_environment
+++ b/blues/templates/pam_env/.pam_environment
@@ -1,0 +1,3 @@
+{%- for key, value in shell_env -%}
+export {{ key }}="{{ value }}"
+{% endfor %}

--- a/blues/templates/pam_env/.pam_environment
+++ b/blues/templates/pam_env/.pam_environment
@@ -1,3 +1,3 @@
 {%- for key, value in shell_env -%}
-export {{ key }}="{{ value }}"
+{{ key }}  DEFAULT="{{ value }}"
 {% endfor %}

--- a/blues/templates/pam_env/.pam_environment
+++ b/blues/templates/pam_env/.pam_environment
@@ -1,3 +1,3 @@
 {%- for key, value in shell_env -%}
-{{ key }}  DEFAULT="{{ value }}"
+{{ '%-30s' % key }}  DEFAULT="{{ value }}"
 {% endfor %}


### PR DESCRIPTION
TODO:

 - [x] Custom variables in blueprint settings?
 - [x] Check if `.env` location is fine
 - [x] It's not! Change it to `~/.profile`
 - [ ] It does not fit well, try `~/.pam_environment`
 - [ ] Check if application part can do it so we don't need extra blueprint