### PR TITLE
git: Strip tty error from git-diff output

### DIFF
--- a/blues/git.py
+++ b/blues/git.py
@@ -213,6 +213,7 @@ def diff_stat(repository_path=None, commit='HEAD^', path=None):
         #    719 files changed, 104452 insertions(+), 29309 deletions(-)
         #    1 file changed, 1 insertion(+)
         output = run('git diff --shortstat {} -- {}'.format(commit, path), pty=False)
+        output = output.lstrip('stdin: is not a tty\n')
         parts = output.strip().split(', ') if output else []
         changed, insertions, deletions = 0, 0, 0
 


### PR DESCRIPTION
This works around a bug in Ubuntu where it tries to run things in root's
.profile that requires a tty without checking if there is one first.