### PR TITLE
neo4j: Fix password changing mechanism

### DIFF
--- a/blues/neo4j.py
+++ b/blues/neo4j.py
@@ -130,7 +130,7 @@ def set_password(old_password='neo4j', user='neo4j'):
     if '"username" : "%s"' % user in output:
         info("Password already set")
 
-    if '"username" : "%s"' % user not in output:
+    else:
         if 'AuthorizationFailed' in output:
             info("Waiting 5 sec due to Jetty's bruteforce protection")
             time.sleep(5)
@@ -143,7 +143,6 @@ def set_password(old_password='neo4j', user='neo4j'):
         new_password = new_password.replace('"', '\\"')
         new_password = new_password.replace("'", "\\'")
 
-        # TODO: it did not work with `-U %s:%s` why?
         output = run(
             'curl -u %s:%s -X POST http://localhost:7474/user/%s/password '
             '-H "Accept: application/json; charset=UTF-8" '


### PR DESCRIPTION
@andreif the password changing mechanism didn't work for me, quite mysteriously actually. I changed it to use the curl option `-u`. This works for me. I also added a message for when the password already works. In the future we might want a `force` flag.