### PR TITLE
Revert "Merge pull request #46 from kyrias/not-a-tty"

### DIFF
--- a/blues/debian.py
+++ b/blues/debian.py
@@ -341,7 +341,7 @@ def service(name, action, check_status=True, show_output=False):
         info('Service: {} {}', name, action)
 
         if check_status:
-            output = run('service {} status'.format(name), combine_stderr=True)
+            output = run('service {} status'.format(name), pty=False, combine_stderr=True)
             if output.return_code != 0:
                 puts(indent(magenta(output)))
                 return
@@ -349,7 +349,7 @@ def service(name, action, check_status=True, show_output=False):
                 puts(indent('...has status {}'.format(magenta(output[len(name)+1:]))))
                 return
 
-        output = run('service {} {}'.format(name, action), combine_stderr=True)
+        output = run('service {} {}'.format(name, action), pty=False, combine_stderr=True)
         if output.return_code != 0 or show_output:
             puts(indent(magenta(output)))
 
@@ -364,7 +364,7 @@ def service_task(name, action, check_status=False, show_output=False):
 def update_rc(basename, priorities, force=False):
     run('update-rc.d {} {} {}'.format('-f' if force else '',
                                       basename,
-                                      priorities), use_sudo=True)
+                                      priorities), pty=False, use_sudo=True)
 
 
 def add_rc_service(name, priorities='defaults'):

--- a/blues/git.py
+++ b/blues/git.py
@@ -99,7 +99,7 @@ def fetch(repository_path=None):
         repository_path = debian.pwd()
 
     with cd(repository_path), silent():
-        run('git fetch origin')
+        run('git fetch origin', pty=False)
 
 
 def show_file(repository_path, filename, revision='HEAD'):
@@ -212,7 +212,7 @@ def diff_stat(repository_path=None, commit='HEAD^', path=None):
         # Example output (note leading space):
         #    719 files changed, 104452 insertions(+), 29309 deletions(-)
         #    1 file changed, 1 insertion(+)
-        output = run('git diff --shortstat {} -- {}'.format(commit, path))
+        output = run('git diff --shortstat {} -- {}'.format(commit, path), pty=False)
         parts = output.strip().split(', ') if output else []
         changed, insertions, deletions = 0, 0, 0
 
@@ -251,7 +251,7 @@ def log(repository_path=None, commit='HEAD', count=1, path=None):
             cmd += ' -{}'.format(count)
         if path:
             cmd += ' -- {}'.format(path)
-        output = run(cmd)
+        output = run(cmd, pty=False)
         git_log = output.stdout.strip()
         git_log = [col.strip() for row in git_log.split('\n') for col in row.split(' ', 1) if col]
         git_log = zip(git_log[::2], git_log[1::2])
@@ -268,7 +268,7 @@ def current_tag(repository_path=None):
     if not repository_path:
         repository_path = debian.pwd()
     with cd(repository_path), silent():
-        output = run('git describe --long --tags --dirty --always')
+        output = run('git describe --long --tags --dirty --always', pty=False)
 
         # 20141114.1-306-g72354ae-dirty
         return output.strip().rsplit('-', 2)[0]


### PR DESCRIPTION
This reverts commit fd5d69837ddb467b63b9ce3408251d727b9f44c4, reversing
changes made to 1f7d5216ab231f617eae28d86622efe5e138ea21.

Git doesn't handle having a pty but not an interactive session well.
We'll solve this by setting env.shell in refabric instead.