### PR TITLE
Run npm/bower install if package.json/bower.json changed

### DIFF
--- a/blues/node.py
+++ b/blues/node.py
@@ -201,7 +201,8 @@ def install_dependencies(path=None, production=True, changed=True):
 
 def create_symlinks(npm_path='../node_modules',
                     bower_path='../bower_components',
-                    bowerrc_path='.bowerrc'):
+                    bowerrc_path='.bowerrc',
+                    clear=False):
 
     with cd(git_repository_path()):
         # get bower components dir from config file
@@ -214,6 +215,8 @@ def create_symlinks(npm_path='../node_modules',
         ]:
             if src:
                 src = os.path.abspath(os.path.join(git_repository_path(), src))
+                if clear:
+                    run('rm -rf {src} || true')
                 run('mkdir -p {src} && ln -sf {src} {dst}'.format(
                     src=src,
                     dst=dst,

--- a/blues/node.py
+++ b/blues/node.py
@@ -173,8 +173,9 @@ def install_dependencies(path=None, production=True, changed=True):
 
     dependency_path_root = path or git_repository_path()
 
-    if not files.exists(os.path.join(dependency_path_root, 'package.json')):
-        return
+    has_file = lambda x: files.exists(os.path.join(dependency_path_root, x))
+    has_package = has_file('package.json')
+    has_bower = has_file('bower.json')
 
     with sudo_project(), cd(dependency_path_root):
 
@@ -185,16 +186,18 @@ def install_dependencies(path=None, production=True, changed=True):
 
             from blues import git
 
-            npm_changed = git.diff_stat(
-                git_repository_path(), changed, 'package.json')[0]
+            if has_package:
+                npm_changed = git.diff_stat(
+                    git_repository_path(), changed, 'package.json')[0]
 
-            bower_changed = git.diff_stat(
-                git_repository_path(), changed, 'bower.json')[0]
+            if has_bower:
+                bower_changed = git.diff_stat(
+                    git_repository_path(), changed, 'bower.json')[0]
 
-        if npm_changed:
+        if has_package and npm_changed:
             run('npm install' + (' --production' if production else ''))
 
-        if bower_changed:
+        if has_bower and bower_changed:
             run('test -f bower.json && '
                 'bower install --config.interactive=false')
 

--- a/blues/node.py
+++ b/blues/node.py
@@ -200,18 +200,21 @@ def install_dependencies(path=None, production=True, changed=True):
 
 
 def create_symlinks(npm_path='../node_modules',
-                    bower_path='../bower_components'):
+                    bower_path='../bower_components',
+                    bowerrc_path='.bowerrc'):
 
     with cd(git_repository_path()):
         # get bower components dir from config file
-        b = run('cat .bowerrc 2>/dev/null || true') or '{}'
+        b = run('cat %s 2>/dev/null || true' % bowerrc_path) or '{}'
         b = json.loads(b).get('directory') or 'bower_components'
 
         for src, dst in [
-            ('../bower_components', b),
-            ('../node_modules', ''),
+            (npm_path, ''),
+            (bower_path, b),
         ]:
-            run('mkdir -p {src} && ln -sf {src} {dst}'.format(
-                src=os.path.abspath(os.path.join(git_repository_path(), src)),
-                dst=dst,
-            ), user=project_name())
+            if src:
+                src = os.path.abspath(os.path.join(git_repository_path(), src))
+                run('mkdir -p {src} && ln -sf {src} {dst}'.format(
+                    src=src,
+                    dst=dst,
+                ), user=project_name())

--- a/blues/node.py
+++ b/blues/node.py
@@ -219,7 +219,7 @@ def create_symlinks(npm_path='../node_modules',
             if src:
                 src = os.path.abspath(os.path.join(git_repository_path(), src))
                 if clear:
-                    run('rm -rf {src} || true')
+                    run('rm -rf {src} || true'.format(src=src))
                 run('mkdir -p {src} && ln -sf {src} {dst}'.format(
                     src=src,
                     dst=dst,


### PR DESCRIPTION
Currently, we reinstall npm/bower packages every time we want to deploy any change. This PR will use symlinks to avoid reinstalling the same packages all over again and also will trigger npm/bower install only if corresponding deps files were modified.

Usage example:

```py
changed = app.deploy(force=force)
node.create_symlinks()  # restore symlinks

if changed or force:
    django.deploy()

    node.install_dependencies(changed=changed or force)
```