### PR TITLE
slack: Support specifying the endpoint with the channel

### DIFF
--- a/blues/slack.py
+++ b/blues/slack.py
@@ -8,9 +8,10 @@ Slack Blueprint
 
     settings:
       slack:
-        endpoint: https://hooks.slack.com/...
+        endpoint: https://hooks.slack.com/... # Default endpoint
         #channels:
         #  - "#deploy"
+        #  - "https://hooks.slack.com/.../#deploy" # Specify non-default endpoint
         #username: deploybot
         #icon_emoji: ":rocket"
 

--- a/blues/slack.py
+++ b/blues/slack.py
@@ -40,12 +40,12 @@ def notify(msg):
     username = blueprint.get('username', 'deploybot')
     icon_emoji = blueprint.get('icon_emoji', ':rocket:')
 
-    endpoint = blueprint.get('endpoint')
-    if not endpoint:
-        warn('No slack API endpoint found, skipping notification')
-        return False
+    endpoint = blueprint.get('endpoint', None)
 
     for channel in channels:
+        if '/' in channel:
+            endpoint, channel = channel.rsplit('/', 1)
+
         send_request(endpoint, channel, username, msg, icon_emoji)
 
 


### PR DESCRIPTION
This will allow sending notifications to different slack teams.