### PR TITLE
Adds newrelic-server setup and newrelic deployment call

### DIFF
--- a/blues/git.py
+++ b/blues/git.py
@@ -268,11 +268,11 @@ def log_between_tags(repository_path, tag1, tag2):
     :param tag2: newset tag
     :return: changelog in text
     """
-    with cd(repository_path), silent():
+    with cd(repository_path):
         cmd = 'git --no-pager log --pretty=oneline {0}..{1}'.format(
             tag1, tag2)
         # removes carriage return
-        changes = run(cmd.replace('\r', ''))
+        changes = run(cmd).replace('\r', '')
         return changes
 
 
@@ -302,7 +302,7 @@ def get_two_most_recent_tags(repository_path):
                    'git --no-pager describe --tags '
                    '"`git --no-pager describe --tags`~1"')
         new_tag, runner_up_tag = tags.strip().split('\n')
-
+        new_tag = new_tag.replace('\r', '')
         return new_tag, runner_up_tag
 
 

--- a/blues/git.py
+++ b/blues/git.py
@@ -259,6 +259,23 @@ def log(repository_path=None, commit='HEAD', count=1, path=None):
     return git_log
 
 
+def log_between_tags(repository_path, tag1, tag2):
+    """
+    get log for repository between 2 tags
+    (--no-pager removes garbled text around the changelog)
+    :param repository_path:
+    :param tag1: oldest tag
+    :param tag2: newset tag
+    :return: changelog in text
+    """
+    with cd(repository_path), silent():
+        cmd = 'git --no-pager log --pretty=oneline {0}..{1}'.format(
+            tag1, tag2)
+        # removes carriage return
+        changes = run(cmd.replace('\r', ''))
+        return changes
+
+
 def current_tag(repository_path=None):
     """
     Get most recent tag
@@ -272,6 +289,21 @@ def current_tag(repository_path=None):
 
         # 20141114.1-306-g72354ae-dirty
         return output.strip().rsplit('-', 2)[0]
+
+
+def get_two_most_recent_tags(repository_path):
+    """
+    Get two most recent tags
+    :param repository_path:
+    :return: new_tag, runner_up_tag
+    """
+    with cd(repository_path), silent():
+        tags = run('git --no-pager describe --tags && '
+                   'git --no-pager describe --tags '
+                   '"`git --no-pager describe --tags`~1"')
+        new_tag, runner_up_tag = tags.strip().split('\n')
+
+        return new_tag, runner_up_tag
 
 
 def parse_url(url, branch=None):

--- a/blues/newrelic.py
+++ b/blues/newrelic.py
@@ -1,0 +1,107 @@
+"""
+NewRelic Server Blueprint
+=================
+
+**Fabric environment:**
+
+.. code-block:: yaml
+
+    blueprints:
+      - blues.newrelic
+
+    settings:
+      newrelic:
+        # newrelic_key: XXXXX
+
+"""
+from fabric.decorators import task
+from refabric.api import run, info
+
+from refabric.context_managers import sudo
+from refabric.contrib import blueprints
+from fabric.context_managers import cd
+from .application.project import python_path
+
+
+from . import debian, git
+
+import requests
+
+__all__ = ['start', 'stop', 'restart', 'setup', 'configure']
+
+
+blueprint = blueprints.get(__name__)
+
+
+start = debian.service_task('newrelic-sysmond', 'start')
+stop = debian.service_task('newrelic-sysmond', 'stop')
+restart = debian.service_task('newrelic-sysmond', 'restart')
+
+
+@task
+def setup():
+    """
+    Install and configure newrelic server
+    """
+    install()
+    configure()
+
+
+def install():
+    with sudo():
+        info('Adding apt repository for Newrelic')
+        debian.add_apt_repository(
+            'http://apt.newrelic.com/debian/ newrelic non-free')
+        info('Adding newrelic apt key')
+        debian.add_apt_key('https://download.newrelic.com/548C16BF.gpg')
+        debian.apt_get('update')
+        info('Installing newrelic-sysmond')
+        debian.apt_get('install', 'newrelic-sysmond')
+
+
+@task
+def configure():
+    """
+    Configure newrelic server
+    """
+
+    with sudo():
+        info('Adding license key to config')
+        newrelic_key = blueprint.get('newrelic_key', None)
+        run('nrsysmond-config --set license_key={}'.format(newrelic_key))
+
+
+def send_deploy_event():
+
+    newrelic_key = blueprint.get('newrelic_key', None)
+    app_name = blueprint.get('app_name', None)
+
+    if newrelic_key and app_name:
+        url = 'https://api.newrelic.com/deployments.xml'
+        headers = {'x-api-key': newrelic_key}
+        with cd(python_path()):
+            commit_hash = run('git rev-parse HEAD')
+            tags = run('git --no-pager describe --tags && git --no-pager describe --tags "`git --no-pager describe --tags`~1"')
+
+            new_tag, old_tag = tags.strip().split('\n')
+
+            cmd = 'git --no-pager log --pretty=oneline %s..%s' % (old_tag,
+            new_tag)
+
+            changes = run(cmd.replace('\r', ''))
+
+        deployer = git.get_local_commiter()
+
+        payload = {
+                'deployment[app_name]': app_name,
+                'deployment[description]': new_tag,
+                'deployment[revision]': commit_hash,
+                'deployment[changelog]': changes,
+                'deployment[user]': deployer,
+            }
+
+        requests.post(url, data=payload, headers=headers)
+
+    else:
+        info('No key found')
+

--- a/blues/newrelic.py
+++ b/blues/newrelic.py
@@ -92,9 +92,10 @@ def send_deploy_event(payload=None):
         headers = {'x-api-key': newrelic_key}
 
         if not payload:
-            commit_hash = git.get_commit(python_path())
-            new_tag, old_tag = git.get_two_most_recent_tags(python_path())
-            changes = git.log_between_tags(python_path(), old_tag, new_tag)
+            path = python_path()
+            commit_hash = git.get_commit(path)
+            new_tag, old_tag = git.get_two_most_recent_tags(path)
+            changes = git.log_between_tags(path, old_tag, new_tag)
             deployer = git.get_local_commiter()
 
             payload = {


### PR DESCRIPTION
Basic blueprint to setup New Relic server.

Notify deployments expects you to use a Git Tag for each deployment and builds a changelog between those tags. 