### PR TITLE
ruby.py legacy support for gem install -v flags

### DIFF
--- a/blues/newrelic.py
+++ b/blues/newrelic.py
@@ -74,22 +74,26 @@ def configure():
 def send_deploy_event(payload=None):
     """
     Sends deploy event to newrelic
-    payload ={
-        'deployment[app_name]': app_name,
-        'deployment[description]': new_tag,
-        'deployment[revision]': commit_hash,
-        'deployment[changelog]': changes,
-        'deployment[user]': deployer,
-    }
-    :param payload: payload is a dict with newrelic api info
+    payload = json.dumps({ 'deployment': {
+            'description': new_tag,
+            'revision': commit_hash,
+            'changelog': changes,
+            'user': deployer,
+            }
+    })
+    :param payload: payload is a json dict with newrelic api info
     :return:
     """
     newrelic_key = blueprint.get('newrelic_key', None)
-    app_name = blueprint.get('app_name', None)
+    app_id = blueprint.get('app_id', None)
 
-    if newrelic_key and app_name:
-        url = 'https://api.newrelic.com/deployments.xml'
-        headers = {'x-api-key': newrelic_key}
+
+    if all([newrelic_key, app_id]):
+        url = 'https://api.newrelic.com/v2/applications/{}/deployments.json'.format(app_id)
+        headers = {
+            'x-api-key': newrelic_key,
+            'Content-Type': 'application/json'
+        }
 
         if not payload:
             path = python_path()
@@ -98,17 +102,19 @@ def send_deploy_event(payload=None):
             changes = git.log_between_tags(path, old_tag, new_tag)
             deployer = git.get_local_commiter()
 
-            payload = {
-                    'deployment[app_name]': app_name,
-                    'deployment[description]': new_tag,
-                    'deployment[revision]': commit_hash,
-                    'deployment[changelog]': changes,
-                    'deployment[user]': deployer,
+            payload = json.dumps({ 
+                'deployment': {
+                    'description': new_tag,
+                    'revision': commit_hash,
+                    'changelog': changes,
+                    'user': deployer,
                 }
+            })
 
         request = urllib2.Request(url, headers=headers)
-        request_payload = urllib.urlencode(payload)
-        urllib2.urlopen(request, data=request_payload)
+        urllib2.urlopen(request, data=payload)
         info('Deploy event sent')
     else:
-        info('No key found')
+        for i in ['app_id', 'newrelic_key']:
+             if not locals().get(i, None):
+                 info('missing key: {}'.format(i))

--- a/blues/newrelic.py
+++ b/blues/newrelic.py
@@ -26,6 +26,7 @@ from . import debian, git
 
 import urllib2
 import urllib
+import json
 
 __all__ = ['start', 'stop', 'restart', 'setup', 'configure']
 

--- a/blues/ruby.py
+++ b/blues/ruby.py
@@ -57,26 +57,39 @@ def install():
 
 def install_gems():
     """
-    Example with 4 kinds of installs supported (at the same time but on
+    Example with 6 kinds of installs supported (at the same time but on
     different rows),
     * no arguments,
     * multiple gems without arguments,
     * a gem with an argument,
     * a gem with multiple arguments
+    * old style specified version
+    * new style specified version
 
     gems:
         gem2
         gem4 gem5 gem6
         gem3 -arg3s
         gem1 -arg1 -arg2
+        gem5 -v 1.0
+        gem6:1.0
     """
     gems = blueprint.get('gems', [])
     if gems:
         info('Installing Gems')
-    # for older versions of gem, you can't install on a single row while
-    # specifying version so we need to loop the install command accordingly.
-    for gem in gems:
-        install_gem(gem)
+        # For older versions of gem (1.9-), you can't install on a single row
+        # while specifying version so we need to loop the install command
+        # accordingly.
+        non_legacy_gems = []
+        for gem in gems:
+            if '-v' in gem or '--version' in gem:
+                install_gem(gem)
+            else:
+                non_legacy_gems.append(gem)
+
+        # For newer versions of gems we can optimize the install call to a
+        # single call, for what it's worth.
+        install_gem(*non_legacy_gems)
 
 
 def install_gem(*options):

--- a/blues/ruby.py
+++ b/blues/ruby.py
@@ -89,7 +89,8 @@ def install_gems():
 
         # For newer versions of gems we can optimize the install call to a
         # single call, for what it's worth.
-        install_gem(*non_legacy_gems)
+        if non_legacy_gems:
+            install_gem(*non_legacy_gems)
 
 
 def install_gem(*options):

--- a/blues/ruby.py
+++ b/blues/ruby.py
@@ -52,17 +52,34 @@ def install():
         debian.apt_get('install', 'ruby1.9.3')
 
     info('Installing Bundler')
-    gem('install', 'bundler')
+    install_gem('bundler')
 
 
 def install_gems():
+    """
+    Example with 4 kinds of installs supported (at the same time but on
+    different rows),
+    * no arguments,
+    * multiple gems without arguments,
+    * a gem with an argument,
+    * a gem with multiple arguments
+
+    gems:
+        gem2
+        gem4 gem5 gem6
+        gem3 -arg3s
+        gem1 -arg1 -arg2
+    """
     gems = blueprint.get('gems', [])
     if gems:
         info('Installing Gems')
-        gem('install', *gems)
+    # for older versions of gem, you can't install on a single row while
+    # specifying version so we need to loop the install command accordingly.
+    for gem in gems:
+        install_gem(gem)
 
 
-def gem(command, *options):
-    info('Running gem {}', command)
+def install_gem(*options):
+    info('Running gem install')
     with sudo():
-        run('gem {} {} --no-ri --no-rdoc'.format(command, ' '.join(options)))
+        run('gem install {} --no-ri --no-rdoc'.format(' '.join(options)))


### PR DESCRIPTION
This will allow you to use the following combinations, allowing for legacy -v flag where single rows must be used for each install command:
```
ruby:
    gems:
        - sass -v 3.4.21
        - compass -v 1.0.3

ruby:
    gems:
        - sass:3.4.21
        - compass:1.0.3

ruby:
    gems:
        - sass:3.4.21 compass:1.0.3

ruby:
    gems:
        - sass compass

ruby:
    gems:
        - sass
        - compass
```