### PR TITLE
Fix `django.count_new_statics()` preventing `django.collectstatic()`

### DIFF
--- a/blues/django.py
+++ b/blues/django.py
@@ -117,7 +117,11 @@ def count_new_statics():
     or None.
     """
     with silent():
-        output = collectstatic(dryrun=True).stdout
+        # NOTE: Don't call `collectstatic(dryrun=True)` here, since that
+        # function is marked with `@runs_once`. That would result in users only
+        # being able to call _either_ `collectstatic` _or_ `count_new_statics`,
+        # but not both.
+        output = manage('collectstatic --noinput -n').stdout
 
         matcher = r'(?P<num>\d+) static files? copied'
 


### PR DESCRIPTION
Here is a real world use case:

```
if django.count_new_statics():
  compile_static()
  django.collectstatic()
```

`django.count_new_statics()` uses `django.collectstatic()` under the
hood, and `django.collectstatic()` is marked with the `@runs_once`
decorator. This means that the `django.collectstatic()` call in the
above example silently no-ops!

This commit simply calls `manage('collectstatic --no-input -n')`
directly in `django.count_new_statics()` instead of calling on
`django.collectstatic()`, fixing the issue.