### PR TITLE
Encapsulate logging settings in a block

### DIFF
--- a/blues/templates/uwsgi/uwsgi/default/vassal.ini
+++ b/blues/templates/uwsgi/uwsgi/default/vassal.ini
@@ -8,12 +8,12 @@ chdir = {{ chdir }}
 home = {{ virtualenv }}
 
 # Logging
-{% block logging %}
+{% block logging -%}
 log-date = true
 log-maxsize = 20971520
 logto = /var/log/uwsgi/%n.log
 logfile-chown = true
-{% endblock %}
+{%- endblock %}
 
 # Keep processes alive
 master = true

--- a/blues/templates/uwsgi/uwsgi/default/vassal.ini
+++ b/blues/templates/uwsgi/uwsgi/default/vassal.ini
@@ -8,10 +8,12 @@ chdir = {{ chdir }}
 home = {{ virtualenv }}
 
 # Logging
+{% block logging %}
 log-date = true
 log-maxsize = 20971520
 logto = /var/log/uwsgi/%n.log
 logfile-chown = true
+{% endblock %}
 
 # Keep processes alive
 master = true


### PR DESCRIPTION
So that logging can be disabled/configured while keeping the rest of the vassal defaults.