### PR TITLE
Bugfix: Fix emperor configuration path

### DIFF
--- a/blues/templates/uwsgi/init/uwsgi.conf
+++ b/blues/templates/uwsgi/init/uwsgi.conf
@@ -4,7 +4,7 @@ description "uWSGI Emperor"
 start on runlevel [2345]
 stop on runlevel [06]
 
-env EMPEROR={{ settings.emperor|default('/srv/app/*/uwsgi.d/') }}
+env EMPEROR={{ settings.emperor|default('/srv/app/*/uwsgi.d/*.ini') }}
 env LOGTO=/var/log/uwsgi/emperor.log
 
 pre-start script
@@ -12,4 +12,4 @@ pre-start script
     chown root:app-data /run/uwsgi/
 end script
 
-exec uwsgi --emperor $EMPEROR --logto $LOGTO
+exec uwsgi --emperor "$EMPEROR" --logto $LOGTO


### PR DESCRIPTION
Value of uWSGI's `--emperor` option needs to be quoted if the path contains wildcards. Otherwise the shell will expand it. That's is not what you want.