### PR TITLE
Solr various

### DIFF
--- a/blues/templates/solr/system/solr.service
+++ b/blues/templates/solr/system/solr.service
@@ -1,0 +1,14 @@
+# Solr script
+[Unit]
+Description=Solr
+After=network.target
+
+[Service]
+User=solr
+Group=solr
+ExecStart=/usr/share/solr/bin/solr start -f -s /etc/solr -m {{ memory }} -a "-Dlog4j.configuration=file:///etc/solr/log4j.properties -Xloggc:/var/log/solr/solr_gc.log"
+TimeoutStopSec=300
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- systemd service for solr (for Ubuntu 16.04 support)
- Don't configure startup scripts for solr version is lesser than 4.0.0

The default behaviour is using built-in jetty to run solr. Lesser than
4.0.0 does have a bundled jetty, but the configuration to run it is not
compatible with blues. So just don't try to configure startup scripts
for those versions.