### PR TITLE
uWSGI blueprint: Fixes

### DIFF
--- a/blues/templates/uwsgi/system/uwsgi.service
+++ b/blues/templates/uwsgi/system/uwsgi.service
@@ -9,6 +9,7 @@ Group=app-data
 Environment=EMPEROR={{ settings.emperor|default('/srv/app/*/uwsgi.d/*.ini') }}
 Environment=LOGTO=/var/log/uwsgi/emperor.log
 RuntimeDirectory=uwsgi
+RuntimeDirectoryMode=0775
 ExecStart=/usr/local/bin/uwsgi --emperor "$EMPEROR" --logto $LOGTO
 Restart=always
 

--- a/blues/uwsgi.py
+++ b/blues/uwsgi.py
@@ -82,6 +82,7 @@ def configure():
         # Upload templates
         if debian.lsb_release() >= '16.04':
             blueprint.upload('system/', '/etc/systemd/system/')
+            run('systemctl daemon-reload', use_sudo=True)
         else:
             blueprint.upload('init/', '/etc/init/')
 


### PR DESCRIPTION
- Fix permission of runtime directory to allow uWSGI emperor vassals to create sockets.
- Issue `systemctl daemon-reload` automatically when `uwsgi.service` is updated