### PR TITLE
nginx: A way of getting IPv4 interfaces with respective addresses

### DIFF
--- a/blues/debian.py
+++ b/blues/debian.py
@@ -562,5 +562,5 @@ def get_ipv4_addresses():
     Returns a dict containing pairs of interface names and their respective
     ipv4 addresses.
     """
-    output = run('ip r show | grep " src " | cut -d " " -f 3,12')
+    output = run('ip r show | grep " src " | awk -F " " \'{print $3 " " $NF}\'')
     return dict(entry.split() for entry in output.split("\n"))

--- a/blues/debian.py
+++ b/blues/debian.py
@@ -555,3 +555,12 @@ def locale_gen(locale, utf8=True):
         run(locale_gen_cmd)
         if utf8:
             run(locale_gen_utf8_cmd)
+
+
+def get_ipv4_addresses():
+    """
+    Returns a dict containing pairs of interface names and their respective
+    ipv4 addresses.
+    """
+    output = run('ip r show | grep " src " | cut -d " " -f 3,12')
+    return dict(entry.split() for entry in output.split("\n"))

--- a/blues/nginx.py
+++ b/blues/nginx.py
@@ -170,7 +170,8 @@ def configure():
     with sudo():
         # Upload templates
         context = {
-            'num_cores': debian.nproc()
+            'num_cores': debian.nproc(),
+            'ipv4_addresses': debian.get_ipv4_addresses(),
         }
         uploads = blueprint.upload('./', nginx_root, context)
 


### PR DESCRIPTION
My scenario is that I needed a nginx server to listen on a private interface, but there was no way of getting the ip address of it inside of a nginx site template. This PR provides a way of doing it.

### Usage example for `debian.get_ipv4_addresses`:
```
>>> debian.get_ipv4_addresses()
{'eth0': '192.168.1.2', 'eth1': '8.8.8.8'}
```

### Example Nginx site configuration:
```
server {
    listen {{ ipv4_addresses.eth0 }}:443 ssl;
    (...)
}
```