### PR TITLE
fix: Latest setuptools breaks on Python 2.7

### DIFF
--- a/blues/application/deploy.py
+++ b/blues/application/deploy.py
@@ -164,6 +164,9 @@ def install_virtualenv():
     with sudo_project():
         virtualenv.create(virtualenv_path())
 
+    with virtualenv.activate(virtualenv_path()):
+        python.upgrade_setuptools()
+
 
 def maybe_install_requirements(previous_commit, current_commit, force=False, update_pip=False):
     from .project import requirements_txt, git_repository_path

--- a/blues/python.py
+++ b/blues/python.py
@@ -88,7 +88,7 @@ def install():
         debian.chmod(pip_log_file, mode=777)
 
         # Install latest setuptools via pip, since debian has on old version.
-        pip('install', 'setuptools', '--upgrade')
+        upgrade_setuptools()
 
 
 def pip(command, *options, **kwargs):
@@ -109,3 +109,16 @@ def pip(command, *options, **kwargs):
 def update_pip():
     info('Updating pip')
     pip('install -U pip')
+
+
+def upgrade_setuptools():
+    """
+    Upgrade setuptools. Limit version to <45 on Python 2.7 since legacy
+    compatibility has been dropped, otherwise install latest.
+    https://setuptools.readthedocs.io/en/latest/history.html#v45-0-0
+    """
+    info("Upgrading setuptools")
+    setuptools_version = (
+        "'setuptools<45'" if requested_version() < (3, 0) else 'setuptools'
+    )
+    pip('install', setuptools_version, '--upgrade')


### PR DESCRIPTION
Limits setuptools to versions below 45 for Python versions below 3.